### PR TITLE
First pass at dropping ancient gotgo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,14 @@
 language: go
 
-# Travis moved checkouts to be outside ${GOPATH%%:*}
-#
-# nb: the -v option to mkdir is not in SUSv4, but is portable enough
-
-go: 1.1
+go: 1.7.4
 
 install:
  - go version
  - repo_dir=$(/bin/pwd -P)
- - spider_parent="github.com/philpennock"
- - SPIDER_DIR="${spider_parent}/sks_spider"
- - DEPS_DIR="${spider_parent}/sks-deps"
- - BTREE_DIR="${DEPS_DIR}/btree"
- - GOTGO_DIR="github.com/droundy/gotgo/gotgo"
- - CHECKOUT_TOP="${GOPATH%%:*}/src"
- - "if ! [ -d \"$CHECKOUT_TOP/$spider_parent\" ]; then mkdir -pv \"$CHECKOUT_TOP/$spider_parent\" && ln -s \"$repo_dir\" \"$CHECKOUT_TOP/$SPIDER_DIR\"; fi"
- - go get -d "$DEPS_DIR"
- - go get -d "$GOTGO_DIR"
- - go build -v "$GOTGO_DIR"
- - ./gotgo -o "$CHECKOUT_TOP/$BTREE_DIR/btree.go" -package-name btree "$CHECKOUT_TOP/$BTREE_DIR/btree.got" string
- - go get -d -v
- - go build -v sks_stats_daemon.go
+ - go get -d -u -v ./...
  - go test -i
+ - make install
+ - ${GOPATH%%:*}/bin/sks_stats_daemon -version
 
 script:
  - go vet

--- a/.version
+++ b/.version
@@ -1,0 +1,8 @@
+#!/bin/sh
+branch="$(git symbolic-ref --short HEAD)"
+if [ ".$branch" = ".master" ]; then
+	branch=""
+else
+	branch=",$branch"
+fi
+printf "%s%s\n" "$(git describe --always --dirty --tags)" "$branch"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,0 +1,45 @@
+ifdef CANONICAL_SKSSPIDER_REPO
+REPO_PATH=      $(CANONICAL_SKSSPIDER_REPO)
+else
+REPO_PATH=      github.com/philpennock/sks_spider
+endif
+
+GO_CMD ?= go
+GO_LDFLAGS:=
+BUILD_TAGS:=
+
+ifndef REPO_VERSION
+REPO_VERSION := $(shell ./.version)
+endif
+GO_LDFLAGS+= -X $(REPO_PATH).VersionString=$(REPO_VERSION)
+
+SOURCES=       $(shell find . -name vendor -prune -o -type f -name '*.go')
+BIN_DIR_TOP := $(firstword $(subst :, ,$(GOPATH)))/bin
+BINARY_NAME := sks_stats_daemon
+BINARY_DIR  := cmd/$(BINARY_NAME)
+BINARY_SRC  := cmd/$(BINARY_NAME)/main.go
+
+.PHONY : all clean install
+.DEFAULT_GOAL := all
+
+all: $(BINARY_DIR)/$(BINARY_NAME)
+
+$(BINARY_DIR)/$(BINARY_NAME): $(BINARY_SRC) $(SOURCES)
+ifeq ($(REPO_VERSION),)
+	@echo "Missing a REPO_VERSION"
+	@false
+endif
+	@echo "Building version $(REPO_VERSION) ..."
+	$(GO_CMD) build -o $@ -tags "$(BUILD_TAGS)" -ldflags "$(GO_LDFLAGS)" -v $<
+
+install: $(BINARY_SRC) $(SOURCES)
+ifeq ($(REPO_VERSION),)
+	@echo "Missing a REPO_VERSION"
+	@false
+endif
+	@echo "Installing version $(REPO_VERSION) ..."
+	rm -f "$(BIN_DIR_TOP)/$(BINARY_NAME)"
+	$(GO_CMD) install -tags "$(BUILD_TAGS)" -ldflags "$(GO_LDFLAGS)" -v $(REPO_PATH)/...
+
+clean:
+	rm -fv $(BINARY_DIR)/$(BINARY_NAME)

--- a/README.md
+++ b/README.md
@@ -5,15 +5,9 @@ Tool to spider the PGP SKS keyserver mesh.
 
 [![Build Status](https://api.travis-ci.org/philpennock/sks_spider.png?branch=master)](https://travis-ci.org/philpennock/sks\_spider)
 
-**Unlikely to build on current Golang**
-
 This code-base is horrible; it was predominantly written in a weekend, porting
-from some very organic Python.  At a bare minimum, this needs to be updated
-to not depend upon `gotgo` but instead to use `go:generate` and manage the
-btree-of-strings accordingly.  The `sks-deps` dependency should be nuked.
-
-Generally, need some basic upkeep.  As-is, this codebase has rotted to
-inedible.  **Beware!**
+from some very organic Python.  Do not use this as an example of how to do
+things in Golang.
 
 
 Overview
@@ -77,32 +71,18 @@ Scott for providing them.
 Building
 --------
 
-For the most part, `go get` should just work.
+To fetch the code, all dependencies, updating them, and install the command,
+then run:
 
-The exception is the btree support from which is very nice, and written
-using generics, with the `gotgo` pre-processor needed to emit a .go file.
+    mkdir ~/go
+    export GOPATH=~/go
 
-The btree code is originally from <https://github.com/runningwild/go-btree>
-but, at time of writing, that has not been updated since before Go 1.0 was
-released and as of Go 1.1, the `go fix` tool will not handle the changes
-needed, so the code has been imported into a dependencies repository,
-<https://github.com/philpennnock/sks-deps>
+    go get -d -u -v github.com/philpennock/sks_spider/...
+    make
 
-Grab https://github.com/droundy/gotgo and put some go1 `// +build ignore`
-magic into a couple of the benchmark files, and you'll be able to build
-the `gotgo` and `gotimports` commands.
-
-In the `sks-deps/btree` directory, run:
-
-    gotgo -o btree.go btree.got string
-
-There's probably a better way to sort out a namespace hierarchy which don't
-expect only one instantiation of the generic, but I was grabbing a btree
-library in passing and didn't investigate fully.
-
-After that, the btree import will work and the code should build with:
-
-    go build github.com/philpennock/sks_spider/sks_stats_daemon.go
+You don't _have_ to use `make`, but it does embed a version string into the
+binary which can be operationally useful.  Note that GNU make should be used
+(or any other make implementation which handles `GNUmakefile` adequately).
 
 If you encounter problems, look at the `.travis.yml` file which is used
 for running the Travis Continuous Integration tests:
@@ -203,4 +183,4 @@ contribute towards the codebase, not take away.  Thanks.
 That's about it.  
 -Phil
 
-Copyright 2012,2013 Phil Pennock.
+Copyright 2012,2013,2016 Phil Pennock.

--- a/cmd/sks_stats_daemon/main.go
+++ b/cmd/sks_stats_daemon/main.go
@@ -1,15 +1,5 @@
-// Wrapper to ensure binary has correct name
-
-// +build ignore
-
-package main
-
-import "github.com/philpennock/sks_spider"
-
-func main() { sks_spider.Main() }
-
 /*
-   Copyright 2009-2012 Phil Pennock
+   Copyright 2009-2012,2016 Phil Pennock
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -23,3 +13,35 @@ func main() { sks_spider.Main() }
    See the License for the specific language governing permissions and
    limitations under the License.
 */
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/philpennock/sks_spider"
+)
+
+var cmdFlags struct {
+	showVersion bool
+}
+
+func init() {
+	flag.BoolVar(&cmdFlags.showVersion, "version", false, "show version & exit")
+}
+
+func main() {
+	flag.Parse()
+
+	if cmdFlags.showVersion {
+		if sks_spider.VersionString == "" {
+			sks_spider.VersionString = "<unknown>"
+		}
+		fmt.Printf("%s: version %s\n", os.Args[0], sks_spider.VersionString)
+		os.Exit(0)
+	}
+
+	sks_spider.Main()
+}

--- a/countries.go
+++ b/countries.go
@@ -1,5 +1,5 @@
 /*
-   Copyright 2009-2012 Phil Pennock
+   Copyright 2009-2012,2016 Phil Pennock
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -19,40 +19,33 @@ package sks_spider
 import (
 	"fmt"
 	"net"
-	"sort"
 	"strconv"
 	"strings"
 )
 
-import (
-	btree "github.com/philpennock/sks-deps/btree"
-)
-
 const hexDigit = "0123456789abcdef"
 
-type CountrySet struct {
-	ss btree.SortedSet
-}
+type CountrySet sortedSet
 
-func NewCountrySet(s string) *CountrySet {
-	cs := &CountrySet{ss: btree.NewTree(btreeStringLess)}
+func NewCountrySet(s string) CountrySet {
+	cs := CountrySet(newSortedSet())
 	for _, country := range strings.Split(s, ",") {
-		cs.ss.Insert(strings.ToUpper(country))
+		sortedSet(cs).Insert(strings.ToUpper(country))
 	}
 	return cs
 }
 
-func (cs *CountrySet) HasCountry(s string) bool {
-	return cs.ss.Contains(strings.ToUpper(s))
+func (cs CountrySet) HasCountry(s string) bool {
+	return sortedSet(cs).Contains(strings.ToUpper(s))
 }
 
-func (cs *CountrySet) String() string {
-	cList := make([]string, 0, cs.ss.Len())
-	for country := range cs.ss.Data() {
-		cList = append(cList, country)
-	}
-	sort.Strings(cList)
+func (cs CountrySet) String() string {
+	cList := sortedSet(cs).AllData()
 	return strings.Join(cList, ",")
+}
+
+func (cs CountrySet) Initialized() bool {
+	return sortedSet(cs).Tree != nil
 }
 
 func reverseIP(ipstr string) (reversed string, err error) {

--- a/diagnostics.go
+++ b/diagnostics.go
@@ -43,7 +43,8 @@ func SpiderDiagnostics(out io.Writer) {
 // spiderMainLoop(), which calls us, will signal on diagnosticSpiderDone when done
 func (spider *Spider) diagnosticDumpInRoutine(out io.Writer) {
 	fmt.Fprintf(out, "BatchAddHost: %d / %d\n", len(spider.batchAddHost), cap(spider.batchAddHost))
-	fmt.Fprintf(out, "Waitgroup: %#+v\n", spider.pending)
+	// We can no longer print %#+v the spider.pending sync.WaitGroup because it's marked noCopy and
+	// the print counts as a copy for the purposes of `go vet`
 	hostnames := make([]string, len(spider.pendingHosts))
 	i := 0
 	for h := range spider.pendingHosts {

--- a/internal/string_set/btree.go
+++ b/internal/string_set/btree.go
@@ -1,0 +1,894 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package b implements a B+tree.
+//
+// Changelog
+//
+// 2014-04-18: Added new method Put.
+//
+// Generic types
+//
+// Keys and their associated values are interface{} typed, similar to all of
+// the containers in the standard library.
+//
+// Semiautomatic production of a type specific variant of this package is
+// supported via
+//
+//	$ make generic
+//
+// This command will write to stdout a version of the btree.go file where
+// every key type occurrence is replaced by the word 'key' (written in all
+// CAPS) and every value type occurrence is replaced by the word 'value'
+// (written in all CAPS). Then you have to replace these tokens with your
+// desired type(s), using any technique you're comfortable with.
+//
+// This is how, for example, 'example/int.go' was created:
+//
+//	$ mkdir example
+//	$
+//	$ # Note: the command bellow must be actually written using the words
+//	$ # 'key' and 'value' in all CAPS. The proper form is avoided in this
+//	$ # documentation to not confuse any text replacement mechanism.
+//	$
+//	$ make generic | sed -e 's/key/int/g' -e 's/value/int/g' > example/int.go
+//
+// No other changes to int.go are (strictly) necessary, it compiles just fine.
+// In a next step, benchmarks from all_test.go were copied into
+// example/bench_test.go without any changes.  A comparator is defined in
+// bench_test.go like this:
+//
+//	func cmp(a, b int) int {
+//		return a - b
+//	}
+//
+// Running the benchmarks on a machine with Intel X5450 CPU @ 3 GHz:
+//
+// Go release (1.1.2)
+//
+//	$ go test -bench . example/bench_test.go example/int.go
+//	testing: warning: no tests to run
+//	PASS
+//	BenchmarkSetSeq	 5000000	       590 ns/op
+//	BenchmarkSetRnd	 1000000	      1530 ns/op
+//	BenchmarkGetSeq	10000000	       373 ns/op
+//	BenchmarkGetRnd	 2000000	      1109 ns/op
+//	BenchmarkDelSeq	 5000000	       672 ns/op
+//	BenchmarkDelRnd	 1000000	      1275 ns/op
+//	BenchmarkSeekSeq	 5000000	       552 ns/op
+//	BenchmarkSeekRnd	 1000000	      1108 ns/op
+//	BenchmarkNext1e3	  200000	     13414 ns/op
+//	BenchmarkPrev1e3	  200000	     13215 ns/op
+//	ok  	command-line-arguments	51.372s
+//	$
+//
+// Go 1.2rc2
+//
+//	$ go test -bench . example/bench_test.go example/int.go
+//	testing: warning: no tests to run
+//	PASS
+//	BenchmarkSetSeq	 5000000	       535 ns/op
+//	BenchmarkSetRnd	 1000000	      1428 ns/op
+//	BenchmarkGetSeq	10000000	       376 ns/op
+//	BenchmarkGetRnd	 2000000	      1105 ns/op
+//	BenchmarkDelSeq	 5000000	       618 ns/op
+//	BenchmarkDelRnd	 1000000	      1213 ns/op
+//	BenchmarkSeekSeq	 5000000	       538 ns/op
+//	BenchmarkSeekRnd	 1000000	      1088 ns/op
+//	BenchmarkNext1e3	  200000	     13410 ns/op
+//	BenchmarkPrev1e3	  200000	     13528 ns/op
+//	ok  	command-line-arguments	48.823s
+//	$
+//
+// Note that the Next and Prev benchmarks enumerate 1000 items (KV pairs), so
+// getting the next or previous iterated item is performed in about 13-14 ns.
+// This is the nice O(1) property of B+trees usually not found in other tree
+// types.
+package btree
+
+import "io"
+
+//TODO check vs orig initialize/finalize
+
+const (
+	kx = 128 //TODO benchmark tune this number if using custom key/value type(s).
+	kd = 64  //TODO benchmark tune this number if using custom key/value type(s).
+)
+
+type (
+	// Cmp compares a and b. Return value is:
+	//
+	//	< 0 if a <  b
+	//	  0 if a == b
+	//	> 0 if a >  b
+	//
+	Cmp func(a, b string) int
+
+	d struct { // data page
+		c int
+		d [2*kd + 1]de
+		n *d
+		p *d
+	}
+
+	de struct { // d element
+		k string
+		v struct{}
+	}
+
+	// Enumerator captures the state of enumerating a tree. It is returned
+	// from the Seek* methods. The enumerator is aware of any mutations
+	// made to the tree in the process of enumerating it and automatically
+	// resumes the enumeration at the proper key, if possible.
+	//
+	// However, once an Enumerator returns io.EOF to signal "no more
+	// items", it does no more attempt to "resync" on tree mutation(s).  In
+	// other words, io.EOF from an Enumaretor is "sticky" (idempotent).
+	Enumerator struct {
+		err error
+		hit bool
+		i   int
+		k   string
+		q   *d
+		t   *Tree
+		ver int64
+	}
+
+	// Tree is a B+tree.
+	Tree struct {
+		c     int
+		cmp   Cmp
+		first *d
+		last  *d
+		r     interface{}
+		ver   int64
+	}
+
+	xe struct { // x element
+		ch  interface{}
+		sep *d
+	}
+
+	x struct { // index page
+		c int
+		x [2*kx + 2]xe
+	}
+)
+
+var ( // R/O zero values
+	zd  d
+	zde de
+	zx  x
+	zxe xe
+)
+
+func clr(q interface{}) {
+	switch x := q.(type) {
+	case *x:
+		for i := 0; i <= x.c; i++ { // Ch0 Sep0 ... Chn-1 Sepn-1 Chn
+			clr(x.x[i].ch)
+		}
+		*x = zx // GC
+	case *d:
+		*x = zd // GC
+	}
+}
+
+// -------------------------------------------------------------------------- x
+
+func newX(ch0 interface{}) *x {
+	r := &x{}
+	r.x[0].ch = ch0
+	return r
+}
+
+func (q *x) extract(i int) {
+	q.c--
+	if i < q.c {
+		copy(q.x[i:], q.x[i+1:q.c+1])
+		q.x[q.c].ch = q.x[q.c+1].ch
+		q.x[q.c].sep = nil // GC
+		q.x[q.c+1] = zxe   // GC
+	}
+}
+
+func (q *x) insert(i int, d *d, ch interface{}) *x {
+	c := q.c
+	if i < c {
+		q.x[c+1].ch = q.x[c].ch
+		copy(q.x[i+2:], q.x[i+1:c])
+		q.x[i+1].sep = q.x[i].sep
+	}
+	c++
+	q.c = c
+	q.x[i].sep = d
+	q.x[i+1].ch = ch
+	return q
+}
+
+func (q *x) siblings(i int) (l, r *d) {
+	if i >= 0 {
+		if i > 0 {
+			l = q.x[i-1].ch.(*d)
+		}
+		if i < q.c {
+			r = q.x[i+1].ch.(*d)
+		}
+	}
+	return
+}
+
+// -------------------------------------------------------------------------- d
+
+func (l *d) mvL(r *d, c int) {
+	copy(l.d[l.c:], r.d[:c])
+	copy(r.d[:], r.d[c:r.c])
+	l.c += c
+	r.c -= c
+}
+
+func (l *d) mvR(r *d, c int) {
+	copy(r.d[c:], r.d[:r.c])
+	copy(r.d[:c], l.d[l.c-c:])
+	r.c += c
+	l.c -= c
+}
+
+// ----------------------------------------------------------------------- Tree
+
+// TreeNew returns a newly created, empty Tree. The compare function is used
+// for key collation.
+func TreeNew(cmp Cmp) *Tree {
+	return &Tree{cmp: cmp}
+}
+
+// Clear removes all K/V pairs from the tree.
+func (t *Tree) Clear() {
+	if t.r == nil {
+		return
+	}
+
+	clr(t.r)
+	t.c, t.first, t.last, t.r = 0, nil, nil, nil
+	t.ver++
+}
+
+func (t *Tree) cat(p *x, q, r *d, pi int) {
+	t.ver++
+	q.mvL(r, r.c)
+	if r.n != nil {
+		r.n.p = q
+	} else {
+		t.last = q
+	}
+	q.n = r.n //TODO recycle r
+	if p.c > 1 {
+		p.extract(pi)
+		p.x[pi].ch = q
+	} else { //TODO recycle r
+		t.r = q
+	}
+}
+
+func (t *Tree) catX(p, q, r *x, pi int) {
+	t.ver++
+	q.x[q.c].sep = p.x[pi].sep
+	copy(q.x[q.c+1:], r.x[:r.c])
+	q.c += r.c + 1
+	q.x[q.c].ch = r.x[r.c].ch //TODO recycle r
+	if p.c > 1 {
+		p.c--
+		pc := p.c
+		if pi < pc {
+			p.x[pi].sep = p.x[pi+1].sep
+			copy(p.x[pi+1:], p.x[pi+2:pc+1])
+			p.x[pc].ch = p.x[pc+1].ch
+			p.x[pc].sep = nil  // GC
+			p.x[pc+1].ch = nil // GC
+		}
+		return
+	}
+
+	t.r = q //TODO recycle r
+}
+
+// Delete removes the k's KV pair, if it exists, in which case Delete returns
+// true.
+func (t *Tree) Delete(k string) (ok bool) {
+	pi := -1
+	var p *x
+	q := t.r
+	if q == nil {
+		return
+	}
+
+	for {
+		var i int
+		i, ok = t.find(q, k)
+		if ok {
+			switch x := q.(type) {
+			case *x:
+				dp := x.x[i].sep
+				switch {
+				case dp.c > kd:
+					t.extract(dp, 0)
+				default:
+					if x.c < kx && q != t.r {
+						t.underflowX(p, &x, pi, &i)
+					}
+					pi = i + 1
+					p = x
+					q = x.x[pi].ch
+					ok = false
+					continue
+				}
+			case *d:
+				t.extract(x, i)
+				if x.c >= kd {
+					return
+				}
+
+				if q != t.r {
+					t.underflow(p, x, pi)
+				} else if t.c == 0 {
+					t.Clear()
+				}
+			}
+			return
+		}
+
+		switch x := q.(type) {
+		case *x:
+			if x.c < kx && q != t.r {
+				t.underflowX(p, &x, pi, &i)
+			}
+			pi = i
+			p = x
+			q = x.x[i].ch
+		case *d:
+			return
+		}
+	}
+}
+
+func (t *Tree) extract(q *d, i int) { // (r generic.U) {
+	t.ver++
+	//r = q.d[i].v // prepared for Extract
+	q.c--
+	if i < q.c {
+		copy(q.d[i:], q.d[i+1:q.c+1])
+	}
+	q.d[q.c] = zde // GC
+	t.c--
+	return
+}
+
+func (t *Tree) find(q interface{}, k string) (i int, ok bool) {
+	var mk string
+	l := 0
+	switch x := q.(type) {
+	case *x:
+		h := x.c - 1
+		for l <= h {
+			m := (l + h) >> 1
+			mk = x.x[m].sep.d[0].k
+			switch cmp := t.cmp(k, mk); {
+			case cmp > 0:
+				l = m + 1
+			case cmp == 0:
+				return m, true
+			default:
+				h = m - 1
+			}
+		}
+	case *d:
+		h := x.c - 1
+		for l <= h {
+			m := (l + h) >> 1
+			mk = x.d[m].k
+			switch cmp := t.cmp(k, mk); {
+			case cmp > 0:
+				l = m + 1
+			case cmp == 0:
+				return m, true
+			default:
+				h = m - 1
+			}
+		}
+	}
+	return l, false
+}
+
+// First returns the first item of the tree in the key collating order, or
+// (zero-value, zero-value) if the tree is empty.
+func (t *Tree) First() (k string, v struct{}) {
+	if q := t.first; q != nil {
+		q := &q.d[0]
+		k, v = q.k, q.v
+	}
+	return
+}
+
+// Get returns the value associated with k and true if it exists. Otherwise Get
+// returns (zero-value, false).
+func (t *Tree) Get(k string) (v struct{}, ok bool) {
+	q := t.r
+	if q == nil {
+		return
+	}
+
+	for {
+		var i int
+		if i, ok = t.find(q, k); ok {
+			switch x := q.(type) {
+			case *x:
+				return x.x[i].sep.d[0].v, true
+			case *d:
+				return x.d[i].v, true
+			}
+		}
+		switch x := q.(type) {
+		case *x:
+			q = x.x[i].ch
+		default:
+			return
+		}
+	}
+}
+
+func (t *Tree) insert(q *d, i int, k string, v struct{}) *d {
+	t.ver++
+	c := q.c
+	if i < c {
+		copy(q.d[i+1:], q.d[i:c])
+	}
+	c++
+	q.c = c
+	q.d[i].k, q.d[i].v = k, v
+	t.c++
+	return q
+}
+
+// Last returns the last item of the tree in the key collating order, or
+// (zero-value, zero-value) if the tree is empty.
+func (t *Tree) Last() (k string, v struct{}) {
+	if q := t.last; q != nil {
+		q := &q.d[q.c-1]
+		k, v = q.k, q.v
+	}
+	return
+}
+
+// Len returns the number of items in the tree.
+func (t *Tree) Len() int {
+	return t.c
+}
+
+func (t *Tree) overflow(p *x, q *d, pi, i int, k string, v struct{}) {
+	t.ver++
+	l, r := p.siblings(pi)
+
+	if l != nil && l.c < 2*kd {
+		l.mvL(q, 1)
+		t.insert(q, i-1, k, v)
+		return
+	}
+
+	if r != nil && r.c < 2*kd {
+		if i < 2*kd {
+			q.mvR(r, 1)
+			t.insert(q, i, k, v)
+		} else {
+			t.insert(r, 0, k, v)
+		}
+		return
+	}
+
+	t.split(p, q, pi, i, k, v)
+}
+
+// Seek returns an Enumerator positioned on a an item such that k >= item's
+// key. ok reports if k == item.key The Enumerator's position is possibly
+// after the last item in the tree.
+func (t *Tree) Seek(k string) (e *Enumerator, ok bool) {
+	q := t.r
+	if q == nil {
+		e = &Enumerator{nil, false, 0, k, nil, t, t.ver}
+		return
+	}
+
+	for {
+		var i int
+		if i, ok = t.find(q, k); ok {
+			switch x := q.(type) {
+			case *x:
+				e = &Enumerator{nil, ok, 0, k, x.x[i].sep, t, t.ver}
+				return
+			case *d:
+				e = &Enumerator{nil, ok, i, k, x, t, t.ver}
+				return
+			}
+		}
+		switch x := q.(type) {
+		case *x:
+			q = x.x[i].ch
+		case *d:
+			e = &Enumerator{nil, ok, i, k, x, t, t.ver}
+			return
+		}
+	}
+}
+
+// SeekFirst returns an enumerator positioned on the first KV pair in the tree,
+// if any. For an empty tree, err == io.EOF is returned and e will be nil.
+func (t *Tree) SeekFirst() (e *Enumerator, err error) {
+	q := t.first
+	if q == nil {
+		return nil, io.EOF
+	}
+
+	return &Enumerator{nil, true, 0, q.d[0].k, q, t, t.ver}, nil
+}
+
+// SeekLast returns an enumerator positioned on the last KV pair in the tree,
+// if any. For an empty tree, err == io.EOF is returned and e will be nil.
+func (t *Tree) SeekLast() (e *Enumerator, err error) {
+	q := t.last
+	if q == nil {
+		return nil, io.EOF
+	}
+
+	return &Enumerator{nil, true, q.c - 1, q.d[q.c-1].k, q, t, t.ver}, nil
+}
+
+// Set sets the value associated with k.
+func (t *Tree) Set(k string, v struct{}) {
+	pi := -1
+	var p *x
+	q := t.r
+	if q != nil {
+		for {
+			i, ok := t.find(q, k)
+			if ok {
+				switch x := q.(type) {
+				case *x:
+					x.x[i].sep.d[0].v = v
+				case *d:
+					x.d[i].v = v
+				}
+				return
+			}
+
+			switch x := q.(type) {
+			case *x:
+				if x.c > 2*kx {
+					t.splitX(p, &x, pi, &i)
+				}
+				pi = i
+				p = x
+				q = x.x[i].ch
+			case *d:
+				switch {
+				case x.c < 2*kd:
+					t.insert(x, i, k, v)
+				default:
+					t.overflow(p, x, pi, i, k, v)
+				}
+				return
+			}
+		}
+	}
+
+	z := t.insert(&d{}, 0, k, v)
+	t.r, t.first, t.last = z, z, z
+	return
+}
+
+// Put combines Get and Set in a more efficient way where the tree is walked
+// only once. The upd(ater) receives (old-value, true) if a KV pair for k
+// exists or (zero-value, false) otherwise. It can then return a (new-value,
+// true) to create or overwrite the existing value in the KV pair, or
+// (whatever, false) if it decides not to create or not to update the value of
+// the KV pair.
+//
+// 	tree.Set(k, v) conceptually equals
+//
+// 	tree.Put(k, func(k, v []byte){ return v, true }([]byte, bool))
+//
+// modulo the differing return values.
+func (t *Tree) Put(k string, upd func(oldV struct{}, exists bool) (newV struct{}, write bool)) (oldV struct{}, written bool) {
+	pi := -1
+	var p *x
+	q := t.r
+	var newV struct{}
+	if q != nil {
+		for {
+			i, ok := t.find(q, k)
+			if ok {
+				switch x := q.(type) {
+				case *x:
+					oldV = x.x[i].sep.d[0].v
+					newV, written = upd(oldV, true)
+					if !written {
+						return
+					}
+
+					x.x[i].sep.d[0].v = newV
+				case *d:
+					oldV = x.d[i].v
+					newV, written = upd(oldV, true)
+					if !written {
+						return
+					}
+
+					x.d[i].v = newV
+				}
+				return
+			}
+
+			switch x := q.(type) {
+			case *x:
+				if x.c > 2*kx {
+					t.splitX(p, &x, pi, &i)
+				}
+				pi = i
+				p = x
+				q = x.x[i].ch
+			case *d: // new KV pair
+				newV, written = upd(newV, false)
+				if !written {
+					return
+				}
+
+				switch {
+				case x.c < 2*kd:
+					t.insert(x, i, k, newV)
+				default:
+					t.overflow(p, x, pi, i, k, newV)
+				}
+				return
+			}
+		}
+	}
+
+	// new KV pair in empty tree
+	newV, written = upd(newV, false)
+	if !written {
+		return
+	}
+
+	z := t.insert(&d{}, 0, k, newV)
+	t.r, t.first, t.last = z, z, z
+	return
+}
+
+func (t *Tree) split(p *x, q *d, pi, i int, k string, v struct{}) {
+	t.ver++
+	r := &d{}
+	if q.n != nil {
+		r.n = q.n
+		r.n.p = r
+	} else {
+		t.last = r
+	}
+	q.n = r
+	r.p = q
+
+	copy(r.d[:], q.d[kd:2*kd])
+	for i := range q.d[kd:] {
+		q.d[kd+i] = zde
+	}
+	q.c = kd
+	r.c = kd
+	if pi >= 0 {
+		p.insert(pi, r, r)
+	} else {
+		t.r = newX(q).insert(0, r, r)
+	}
+	if i > kd {
+		t.insert(r, i-kd, k, v)
+		return
+	}
+
+	t.insert(q, i, k, v)
+}
+
+func (t *Tree) splitX(p *x, pp **x, pi int, i *int) {
+	t.ver++
+	q := *pp
+	r := &x{}
+	copy(r.x[:], q.x[kx+1:])
+	q.c = kx
+	r.c = kx
+	if pi >= 0 {
+		p.insert(pi, q.x[kx].sep, r)
+	} else {
+		t.r = newX(q).insert(0, q.x[kx].sep, r)
+	}
+	q.x[kx].sep = nil
+	for i := range q.x[kx+1:] {
+		q.x[kx+i+1] = zxe
+	}
+	if *i > kx {
+		*pp = r
+		*i -= kx + 1
+	}
+}
+
+func (t *Tree) underflow(p *x, q *d, pi int) {
+	t.ver++
+	l, r := p.siblings(pi)
+
+	if l != nil && l.c+q.c >= 2*kd {
+		l.mvR(q, 1)
+	} else if r != nil && q.c+r.c >= 2*kd {
+		q.mvL(r, 1)
+		r.d[r.c] = zde // GC
+	} else if l != nil {
+		t.cat(p, l, q, pi-1)
+	} else {
+		t.cat(p, q, r, pi)
+	}
+}
+
+func (t *Tree) underflowX(p *x, pp **x, pi int, i *int) {
+	t.ver++
+	var l, r *x
+	q := *pp
+
+	if pi >= 0 {
+		if pi > 0 {
+			l = p.x[pi-1].ch.(*x)
+		}
+		if pi < p.c {
+			r = p.x[pi+1].ch.(*x)
+		}
+	}
+
+	if l != nil && l.c > kx {
+		q.x[q.c+1].ch = q.x[q.c].ch
+		copy(q.x[1:], q.x[:q.c])
+		q.x[0].ch = l.x[l.c].ch
+		q.x[0].sep = p.x[pi-1].sep
+		q.c++
+		*i++
+		l.c--
+		p.x[pi-1].sep = l.x[l.c].sep
+		return
+	}
+
+	if r != nil && r.c > kx {
+		q.x[q.c].sep = p.x[pi].sep
+		q.c++
+		q.x[q.c].ch = r.x[0].ch
+		p.x[pi].sep = r.x[0].sep
+		copy(r.x[:], r.x[1:r.c])
+		r.c--
+		rc := r.c
+		r.x[rc].ch = r.x[rc+1].ch
+		r.x[rc].sep = nil
+		r.x[rc+1].ch = nil
+		return
+	}
+
+	if l != nil {
+		*i += l.c + 1
+		t.catX(p, l, q, pi-1)
+		*pp = l
+		return
+	}
+
+	t.catX(p, q, r, pi)
+}
+
+// ----------------------------------------------------------------- Enumerator
+
+// Next returns the currently enumerated item, if it exists and moves to the
+// next item in the key collation order. If there is no item to return, err ==
+// io.EOF is returned.
+func (e *Enumerator) Next() (k string, v struct{}, err error) {
+	if err = e.err; err != nil {
+		return
+	}
+
+	if e.ver != e.t.ver {
+		f, hit := e.t.Seek(e.k)
+		if !e.hit && hit {
+			if err = f.next(); err != nil {
+				return
+			}
+		}
+
+		*e = *f
+	}
+	if e.q == nil {
+		e.err, err = io.EOF, io.EOF
+		return
+	}
+
+	if e.i >= e.q.c {
+		if err = e.next(); err != nil {
+			return
+		}
+	}
+
+	i := e.q.d[e.i]
+	k, v = i.k, i.v
+	e.k, e.hit = k, false
+	e.next()
+	return
+}
+
+func (e *Enumerator) next() error {
+	if e.q == nil {
+		e.err = io.EOF
+		return io.EOF
+	}
+
+	switch {
+	case e.i < e.q.c-1:
+		e.i++
+	default:
+		if e.q, e.i = e.q.n, 0; e.q == nil {
+			e.err = io.EOF
+		}
+	}
+	return e.err
+}
+
+// Prev returns the currently enumerated item, if it exists and moves to the
+// previous item in the key collation order. If there is no item to return, err
+// == io.EOF is returned.
+func (e *Enumerator) Prev() (k string, v struct{}, err error) {
+	if err = e.err; err != nil {
+		return
+	}
+
+	if e.ver != e.t.ver {
+		f, hit := e.t.Seek(e.k)
+		if !e.hit && hit {
+			if err = f.prev(); err != nil {
+				return
+			}
+		}
+
+		*e = *f
+	}
+	if e.q == nil {
+		e.err, err = io.EOF, io.EOF
+		return
+	}
+
+	if e.i >= e.q.c {
+		if err = e.next(); err != nil {
+			return
+		}
+	}
+
+	i := e.q.d[e.i]
+	k, v = i.k, i.v
+	e.k, e.hit = k, false
+	e.prev()
+	return
+}
+
+func (e *Enumerator) prev() error {
+	if e.q == nil {
+		e.err = io.EOF
+		return io.EOF
+	}
+
+	switch {
+	case e.i > 0:
+		e.i--
+	default:
+		if e.q = e.q.p; e.q == nil {
+			e.err = io.EOF
+			break
+		}
+
+		e.i = e.q.c - 1
+	}
+	return e.err
+}

--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
 /*
-   Copyright 2009-2013 Phil Pennock
+   Copyright 2009-2013,2016 Phil Pennock
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -52,6 +52,8 @@ var (
 	flStartedFlagfile    = flag.String("started-file", "", "Create this file after started and running")
 	flHttpFetchTimeout   = flag.Duration("http-fetch-timeout", 2*time.Minute, "Timeout for HTTP fetch from SKS servers")
 )
+
+var VersionString string
 
 var serverHeadersNative = map[string]bool{
 	"sks_www": true,
@@ -209,7 +211,9 @@ func shutdownRunner(ch <-chan os.Signal) {
 }
 
 func Main() {
-	flag.Parse()
+	if !flag.Parsed() {
+		flag.Parse()
+	}
 
 	if *flScanIntervalJitter < 0 {
 		fmt.Fprintf(os.Stderr, "Bad jitter, must be >= 0 [got: %d]\n", *flScanIntervalJitter)

--- a/sorted_set.go
+++ b/sorted_set.go
@@ -1,0 +1,129 @@
+/*
+   Copyright 2016 Phil Pennock
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package sks_spider
+
+// sorted set of strings:
+//go:generate gengen -o ./internal/string_set github.com/joeshaw/gengen/examples/btree string struct{}
+
+import (
+	"strings"
+
+	btree "github.com/philpennock/sks_spider/internal/string_set"
+)
+
+type sortedSet struct {
+	*btree.Tree
+}
+
+func newSortedSet() sortedSet {
+	return sortedSet{
+		Tree: btree.TreeNew(strings.Compare),
+	}
+}
+
+// eww, code smell XXX
+func hostCompare(a, b string) int {
+	a1 := strings.Split(a, ".")
+	b1 := strings.Split(b, ".")
+	ReverseStringSlice(a1)
+	ReverseStringSlice(b1)
+	a2 := strings.Join(a1, ".")
+	b2 := strings.Join(b1, ".")
+	return strings.Compare(a2, b2)
+}
+
+func newHostReversedSet() sortedSet {
+	return sortedSet{
+		Tree: btree.TreeNew(hostCompare),
+	}
+}
+
+func (set sortedSet) Insert(key string) {
+	set.Tree.Set(key, struct{}{})
+}
+
+func (set sortedSet) Contains(key string) bool {
+	_, ok := set.Tree.Seek(key)
+	return ok
+}
+
+func (set sortedSet) Len() int {
+	return set.Tree.Len()
+}
+
+func (set sortedSet) Remove(key string) {
+	_ = set.Tree.Delete(key)
+}
+
+func (set sortedSet) Data() <-chan string {
+	ch := make(chan string, 100)
+	go func(c chan<- string) {
+		enum, err := set.Tree.SeekFirst()
+		if err != nil {
+			close(c)
+			return
+		}
+		for {
+			k, _, err := enum.Next()
+			if err != nil {
+				break
+			}
+			c <- k
+		}
+		close(c)
+		// enum.Close() -- in github.com/cznic/b docs but not in template
+		return
+	}(ch)
+	return ch
+}
+
+func (set sortedSet) AllData() []string {
+	if set.Tree.Len() == 0 {
+		return nil
+	}
+	dl := make([]string, 0, set.Tree.Len())
+	enum, err := set.Tree.SeekFirst()
+	if err != nil {
+		return dl
+	}
+	for {
+		k, _, err := enum.Next()
+		if err != nil {
+			break
+		}
+		dl = append(dl, k)
+	}
+	// enum.Close() -- in github.com/cznic/b docs but not in template
+	return dl
+}
+
+type collectionOfSortedSets map[string]sortedSet
+
+func newCollectionOfSortedSets(size int) collectionOfSortedSets {
+	return make(collectionOfSortedSets, size)
+}
+
+func (css collectionOfSortedSets) Ensure(key string) {
+	if _, ok := css[key]; !ok {
+		css[key] = newSortedSet()
+	}
+}
+
+func (css collectionOfSortedSets) Insert(key, setKey string) {
+	css.Ensure(key)
+	css[key].Insert(setKey)
+}


### PR DESCRIPTION
Move to a sorted_set wrapper around a go-generate derived code-base,
built using the btree from github.com/joeshaw/gengen

Drop ancient Travis cruft, update to current Go as the test version.

Pull in a GNUmakefile and .version, based on character's.

Move the binary into a separate dir, instead of being build-ignored in
main dir.